### PR TITLE
Fixed overflow exception on null-length strings

### DIFF
--- a/Srcs/common/bitstream.cpp
+++ b/Srcs/common/bitstream.cpp
@@ -339,8 +339,8 @@ void BitStream::readZeroTerminatedString(string& dstString)
     char currChar;
 
     dstString.clear();
-    currChar = read8Bits();
-    while (currChar != '\0')
+
+    while (mByteOffset != getSize() && (currChar = read8Bits()) != '\0')
     {
         dstString += currChar;
         currChar = read8Bits();


### PR DESCRIPTION
Observed while parsing some .heic image from iOS 11