### PR TITLE
fix building error: no type named ‘difference_type’  on gcc version 4.8.5

### DIFF
--- a/srcs/common/customallocator.hpp
+++ b/srcs/common/customallocator.hpp
@@ -114,6 +114,7 @@ public:
     using const_pointer = const T*;
     using reference = T&;
     using const_reference =const T&;
+    using difference_type = std::ptrdiff_t;
     template <typename U>
     struct rebind
     {


### PR DESCRIPTION
CentOS Linux release 7.2.1511 (Core)
gcc version 4.8.5 20150623 (Red Hat 4.8.5-11) (GCC)

Building error:
/usr/include/c++/4.8.2/bits/basic_string.h: In instantiation of ‘class std::basic_string<char, std::char_traits<char>, Allocator<char> >’:
/home/jimin/dev/heif/caijimin/heif/srcs/common/customallocator.hpp:227:24:   required from here
/usr/include/c++/4.8.2/bits/basic_string.h:122:61: error: no type named ‘difference_type’ in ‘std::basic_string<char, std::char_traits<char>, Allocator<char> >::_CharT_alloc_type {aka class Allocator<char>}’
       typedef typename _CharT_alloc_type::difference_type   difference_type;
