### PR TITLE
JPEG files can contain XMP data

### DIFF
--- a/technical.html
+++ b/technical.html
@@ -531,7 +531,7 @@
                                 Exif, XMP, MPEG-7
                             </td>
                             <td>
-                                Exif
+                                Exif, XMP
                             </td>
                             <td>
                                 -


### PR DESCRIPTION
See e.g. https://en.wikipedia.org/wiki/Extensible_Metadata_Platform#Embedding, or XMPSpecificationPart3.pdf page 18.

This is widely used in practice – for example, every JPEG written by Lightroom Classic, a Sony Alpha camera, or a Google Pixel phone contains XMP data.